### PR TITLE
fix: Use correct syntax to stringify results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cli.js
+++ b/cli.js
@@ -33,10 +33,10 @@ if (files.length === 0) {
 }
 
 stylelintDisable({rules, files}).then(results => {
-  for (const {source, root, disabled} of results) {
+  for (const {source, root, disabled, syntax} of results) {
     console.warn(`Writing ${disabled} disables to ${source}...`)
     if (!dryRun) {
-      let css = root.toString()
+      let css = root.toString(syntax)
       // XXX: this is a fix for some trailing spaces in comments that show up
       // even though we set {raws: {after: ''}} in the comment node
       // :thinking_face:

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = function stylelintDisable(options) {
         results.push({
           source,
           root,
-          disabled
+          disabled,
+          syntax: result.opts.syntax,
         })
       }
     }


### PR DESCRIPTION
For folks using custom syntaxes (like `postcss-less`), this package does not use that syntax to stringify them. This PR changes the code to use the `syntax` provided on the Stylelint result object, which mirrors how Stylelint itself stringifies ASTs:

https://github.com/stylelint/stylelint/blob/076ef6dfefff0e58dbbb437ad5eeb45e98b5da5b/lib/standalone.js#L242

Note that all PostCSS syntax nodes accept an optional stringifier argument to their `toString()` function:

https://postcss.org/api/#root-tostring

**Note:** I've only tested this on the latest version of Stylelint (v14). It may not work with previous versions. If you're comfortable with me bumping the minimum version of Stylelint in `package.json`, I'd be happy to do that and update the README accordingly! 